### PR TITLE
added POC static benchmark target

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,7 +45,7 @@ else()
       message( " |    1. Clone the repository: git clone git@github.com:OPM/opm-cmake.git        |")
       message( " |                                                                               |")
       message( " |    2. Run cmake in the current project with -DOPM_CMAKE_ROOT=<path>/opm-cmake |")
-      message( " |                                                                               |") 
+      message( " |                                                                               |")
       message( " \\-------------------------------------------------------------------------------/")
       message( "" )
       message( FATAL_ERROR "Could not find OPM Macros")
@@ -87,6 +87,14 @@ endmacro (tests_hook)
 
 # all setup common to the OPM library modules is done here
 include (OpmLibMain)
+
+# Setup static targets
+include(OpmStaticTargets)
+
+from_git(https://github.com/OPM/opm-benchmarks opm-benchmarks ${OPM_BENCHMARK_VERSION})
+add_dependencies(opm-benchmarks-static opm-upscaling-static)
+add_custom_target(static-benchmarks)
+add_dependencies(static-benchmarks opm-benchmarks-static)
 
 # encode test cases so they can be embedded in the executable
 include (${PROJECT_SOURCE_DIR}/EmbedCases.cmake)


### PR DESCRIPTION
This PR IS *NOT* INTENDED FOR INCLUSION.

I have been tasked with getting rid of opm-benchmarks and integrating in the relevant repository (currently only opm-upscaling).

until we decide how to pull in the data, this is a POC to allow testing the system.

it adds a target `static-benchmarks` which will build a completely static benchmark executable. currently it reused opm-benchmarks, but this part will obviously be changed once we decide on the other bits.

I would appreciate if somebody could try this on their system. It's not been heavily tested yet.

configure as normal, then use `make static-benchmarks`. just `make` will build the benchmark as normal.